### PR TITLE
Project manager job posting

### DIFF
--- a/blog/2023-03-17-project-coordinator.md
+++ b/blog/2023-03-17-project-coordinator.md
@@ -4,7 +4,7 @@ title: "OpenRefine is looking for a part time project coordinator"
 ---
 
 OpenRefine is looking for a part time project coordinator.
-This paid role is intended to help facilitate community processes in the project, improve our capacity to liaise with partners and our gouvernance structures.
+This paid role is intended to help facilitate community processes in the project, improve our capacity to liaise with partners and our governance structures.
 
 The responsibilities of this project coordinator will include:
 * Facilitating regular meetings within the OpenRefine community and with external partners;

--- a/blog/2023-03-17-project-coordinator.md
+++ b/blog/2023-03-17-project-coordinator.md
@@ -30,6 +30,7 @@ This role will be compensated depending on the applicant's experience, from $40 
 We anticipate a time commitment from 10h to 30h per week depending on the applicant's availability.
 The position can be filled as soon as possible, with a trial period of 3 months.
 Code for Science and Society is able to hire collaborators in most jurisdictions not targeted by US sanctions, via a local employer of record.
+The project coordinator will report to the advisory committee, which currently consists of Martin Magdinier, Antonin Delpeuch and Jan Ainali.
 
 To respond to this opportunity, send your application (CV and short motivation statement) to hiring@openrefine.org.
 Applications will be reviewed until March 30th and we aim to respond to all candidates.

--- a/blog/2023-03-17-project-coordinator.md
+++ b/blog/2023-03-17-project-coordinator.md
@@ -33,6 +33,6 @@ Code for Science and Society is able to hire collaborators in most jurisdictions
 The project coordinator will report to the advisory committee, which currently consists of Martin Magdinier, Antonin Delpeuch and Jan Ainali.
 
 To respond to this opportunity, send your application (CV and short motivation statement) to hiring@openrefine.org.
-Applications will be reviewed until March 30th and we aim to respond to all candidates.
+We will start to review applications on March 25th and we aim to respond to all candidates.
 
 *OpenRefine is fiscally sponsored by Code for Science and Society (CS&S). CS&S is an equal opportunity employer committed to hiring a diverse workforce at all levels of the organization thereby creating a culture that allows us to better serve our clientele, our employees and our communities. We value and encourage the contributions of our colleagues and strive to create an environment where everyone can reach their full potential and drive outstanding results. All qualified applicants will receive consideration for employment without regard to race, national origin, age, sex, religion, disability, sexual orientation, marital status, veteran status, gender identity or expression, or any other basis protected by local, state, or federal law. This policy applies with regard to all aspects of one's employment, including hiring, transfer, promotion, compensation, eligibility for benefits, and termination.*

--- a/blog/2023-03-17-project-coordinator.md
+++ b/blog/2023-03-17-project-coordinator.md
@@ -1,0 +1,37 @@
+---
+author: Antonin Delpeuch
+title: "OpenRefine is looking for a part time project coordinator"
+---
+
+OpenRefine is looking for a part time project coordinator.
+This paid role is intended to help facilitate community processes in the project, improve our capacity to liaise with partners and our gouvernance structures.
+
+The responsibilities of this project coordinator will include:
+* Facilitating regular meetings within the OpenRefine community and with external partners;
+* Run outreach activities such as our biyearly user survey or by representing the project in events;
+* Maintain the project's communication channels (such as moderating the forum)
+* Help organize in-person events for the OpenRefine community
+* Coordinate our participation in internship programmes such as Outreachy or Google Summer of Code;
+* Help with grant applications and reporting
+* Liaise with Code for Science and Society, our fiscal sponsor
+
+The scope of the role is anticipated to evolve, to adapt to the coordinator's interests and the project's needs.
+
+Requirements:
+* Good communication skills and fluency in English, both written and spoken
+* Self-motivated and organized
+* Able to work fully remotely
+
+Nice to have:
+* Experience with working in a volunteer organization
+* Familiarity with OpenRefine or a related open source project
+
+This role will be compensated depending on the applicant's experience, from $40 to $70 per hour.
+We anticipate a time commitment from 10h to 30h per week depending on the applicant's availability.
+The position can be filled as soon as possible, with a trial period of 3 months.
+Code for Science and Society is able to hire collaborators in most jurisdictions not targeted by US sanctions, via a local employer of record.
+
+To respond to this opportunity, send your application (CV and short motivation statement) to hiring@openrefine.org.
+Applications will be reviewed until March 30th and we aim to respond to all candidates.
+
+*OpenRefine is fiscally sponsored by Code for Science and Society (CS&S). CS&S is an equal opportunity employer committed to hiring a diverse workforce at all levels of the organization thereby creating a culture that allows us to better serve our clientele, our employees and our communities. We value and encourage the contributions of our colleagues and strive to create an environment where everyone can reach their full potential and drive outstanding results. All qualified applicants will receive consideration for employment without regard to race, national origin, age, sex, religion, disability, sexual orientation, marital status, veteran status, gender identity or expression, or any other basis protected by local, state, or federal law. This policy applies with regard to all aspects of one's employment, including hiring, transfer, promotion, compensation, eligibility for benefits, and termination.*

--- a/blog/2023-03-17-project-coordinator.md
+++ b/blog/2023-03-17-project-coordinator.md
@@ -21,10 +21,11 @@ Requirements:
 * Good communication skills and fluency in English, both written and spoken
 * Self-motivated and organized
 * Able to work fully remotely
+* Familiarity with OpenRefine or a related open source project
 
 Nice to have:
 * Experience with working in a volunteer organization
-* Familiarity with OpenRefine or a related open source project
+* Ability to travel to events a couple of times a year
 
 This role will be compensated depending on the applicant's experience, from $40 to $70 per hour.
 We anticipate a time commitment from 10h to 30h per week depending on the applicant's availability.

--- a/blog/2023-03-17-project-coordinator.md
+++ b/blog/2023-03-17-project-coordinator.md
@@ -1,12 +1,12 @@
 ---
 author: Antonin Delpeuch
-title: "OpenRefine is looking for a part time project coordinator"
+title: "OpenRefine is looking for a part time project manager"
 ---
 
-OpenRefine is looking for a part time project coordinator.
+OpenRefine is looking for a part time project manager.
 This paid role is intended to help facilitate community processes in the project, improve our capacity to liaise with partners and our governance structures.
 
-The responsibilities of this project coordinator will include:
+The responsibilities of this project manager will include:
 * Facilitating regular meetings within the OpenRefine community and with external partners;
 * Run outreach activities such as our biyearly user survey or by representing the project in events;
 * Maintain the project's communication channels (such as moderating the forum)
@@ -15,7 +15,7 @@ The responsibilities of this project coordinator will include:
 * Help with grant applications and reporting
 * Liaise with Code for Science and Society, our fiscal sponsor
 
-The scope of the role is anticipated to evolve, to adapt to the coordinator's interests and the project's needs.
+The scope of the role is anticipated to evolve, to adapt to the manager's interests and the project's needs.
 
 Requirements:
 * Good communication skills and fluency in English, both written and spoken
@@ -30,8 +30,8 @@ Nice to have:
 This role will be compensated depending on the applicant's experience, from $40 to $70 per hour.
 We anticipate a time commitment from 10h to 30h per week depending on the applicant's availability.
 The position can be filled as soon as possible, with a trial period of 3 months.
-Code for Science and Society is able to hire collaborators in most jurisdictions not targeted by US sanctions, via a local employer of record.
-The project coordinator will report to the advisory committee, which currently consists of Martin Magdinier, Antonin Delpeuch and Jan Ainali.
+Code for Science and Society [is able to hire collaborators in most jurisdictions not targeted by US sanctions](https://www.codeforsociety.org/resources/international-hiring-guide), via a local employer of record.
+The project manager will report to the advisory committee, which currently consists of Martin Magdinier, Antonin Delpeuch and Jan Ainali.
 
 To respond to this opportunity, send your application (CV and short motivation statement) to hiring@openrefine.org.
 We will start to review applications on March 25th and we aim to respond to all candidates.


### PR DESCRIPTION
This is a draft for a job posting for a project coordinator, following the vacancy of the former project director role.

Given feedback from various people, the advisory committee wants to change the scope of the role to emphasize more of a coordination role, with the intention to give more decision power to the broader community.

Feedback welcome, not just on the language but also on the job's scope and conditions itself.

Pinging @ainali @magdmartin (as advisory committee members) and @Vesihiisi @libcce @lozanaross (as active steering committee members): what do you think of this? If you are not interested in applying yourself, would you be interested in reviewing applicants?