### PR TITLE
Add Mastodon link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -132,7 +132,7 @@ module.exports = {
             },
             {
               html: `
-                  <a rel="me" class="footer__link-item" target="_blank" href="https://fosstodon.org/@OpenRefine">Mastodon</a>
+                  <a rel="me" class="footer__link-item" target="_blank" href="https://fosstodon.org/@OpenRefine">Mastodon<svg width="13.5" height="13.5" aria-hidden="true" viewBox="0 0 24 24" class="iconExternalLink_node_modules-@docusaurus-theme-classic-lib-theme-Icon-ExternalLink-styles-module"><path fill="currentColor" d="M21 13v10h-21v-19h12v2h-10v15h17v-8h2zm3-12h-10.988l4.035 4-6.977 7.07 2.828 2.828 6.977-7.07 4.125 4.172v-11z"></path></svg></a>
                 `
             },
           ],

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -130,6 +130,11 @@ module.exports = {
               label: 'Twitter',
               href: 'https://twitter.com/openrefine',
             },
+            {
+              html: `
+                  <a rel="me" class="footer__link-item" target="_blank" href="https://fosstodon.org/@OpenRefine">Mastodon</a>
+                `
+            },
           ],
         },
       ],


### PR DESCRIPTION
This adds a link to our Mastodon profile. Sadly, because Mastodon relies on the presence of the `rel="me"` attribute, we need to put explicit HTML in there for profile verification to work. To get the same rendering as other external links, we seemingly need to include this small SVG as well.

There might be better approaches?

![image](https://github.com/OpenRefine/openrefine.org/assets/309908/33b5a01b-80ca-4b32-8ad1-601e6b30fb82)
