### PR TITLE
Set home page title to just 'OpenRefine'

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -60,7 +60,7 @@ export default function Home(): JSX.Element {
   } = useDocusaurusContext();
   const {description} = customFields as {description: string};
   return (
-    <Layout title="OpenRefine" description={description}>
+    <Layout description={description}>
       <main>
         <HeaderSection />
       </main>


### PR DESCRIPTION
This changes the title of the home page from "OpenRefine | OpenRefine" to just "OpenRefine".
For #215.

Adding the tag line seems more involved, but that feels like an improvement already.