### PR TITLE
Enable CORS headers for /versions.json

### DIFF
--- a/static/_headers
+++ b/static/_headers
@@ -1,0 +1,2 @@
+/versions.json
+  Access-Control-Allow-Origin: *


### PR DESCRIPTION
This should let anyone fetch the latest OpenRefine version, regardless of their origin. (Funny, this suddenly reads like a social justice campaign…)

For https://github.com/OpenRefine/OpenRefine/issues/6017.

I haven't tested it yet, but according to https://stackoverflow.com/a/62528017/985087 it should do the trick.