### PR TITLE
Introduce Windows installer

### DIFF
--- a/src/releases.js
+++ b/src/releases.js
@@ -7,15 +7,15 @@
 const releases = require('../releases.json');
  
 const platformDetails = {
-        'win-with-java': {
+        'win-with-java-installer': {
                 name: 'Windows',
-                fullName: 'Windows (including\u00A0Java)',
+                fullName: 'Windows (installer)',
                 embedsJava: true
         },
-        'win': {
+        'win-with-java': {
                 name: 'Windows',
-                fullName: 'Windows (without\u00A0Java)',
-                embedsJava: false
+                fullName: 'Windows (zip\u00A0file)',
+                embedsJava: true
         },
         'mac': {
                 name: 'Mac OS',
@@ -29,7 +29,7 @@ const platformDetails = {
         }
 };
 
-const platformOrder = ['win-with-java', 'win', 'mac', 'linux'];
+const platformOrder = ['win-with-java-installer', 'win-with-java', 'mac', 'linux'];
 
 function getArtifact(release, platform) {
     let matching = release.artifacts.filter(a => a.platform === platform);


### PR DESCRIPTION
This prepares the website for the 3.8 release, introducing the Windows installer as one of the possible downloads.
It also drops the Windows zip file without java included [as suggested on the forum](https://forum.openrefine.org/t/releasing-3-8-beta1/1136).

I expect we will want to make the installer the default choice on Windows, but I would only make this shift once we have a stable release in the 3.8 series.

This PR should only be merged when we release 3.8-beta1, since it will otherwise display an empty column in the release table.

See preview of the download page: https://deploy-preview-298--openrefine-website.netlify.app/download