### PR TITLE
Fix #331 Meet accessible contrast ratio

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -9,13 +9,13 @@
 
  /* Primary color meets WCAG AA contrast ratio of 4.5:1 */
  :root {
-    --ifm-color-primary: #2272a0;
-    --ifm-color-primary-dark: #1f6790;
-    --ifm-color-primary-darker: #1d6188;
-    --ifm-color-primary-darkest: #185070;
-    --ifm-color-primary-light: #257db0;
-    --ifm-color-primary-lighter: #2783b8;
-    --ifm-color-primary-lightest: #2c94d0;
+    --ifm-color-primary: #005e94;
+    --ifm-color-primary-dark: #005585;
+    --ifm-color-primary-darker: #00507e;
+    --ifm-color-primary-darkest: #004268;
+    --ifm-color-primary-light: #0067a3;
+    --ifm-color-primary-lighter: #006caa;
+    --ifm-color-primary-lightest: #007ac0;
     --ifm-color-secondary: #999999;
     --ifm-alert-border-width: 0.375em;
     --ifm-alert-background-color: #ffffff;
@@ -25,13 +25,13 @@
   }
 
   [data-theme='dark'] {
-    --ifm-color-primary: #47bcff;
-    --ifm-color-primary-dark: #26b0ff;
-    --ifm-color-primary-darker: #16aaff;
-    --ifm-color-primary-darkest: #0091e4;
-    --ifm-color-primary-light: #68c8ff;
-    --ifm-color-primary-lighter: #78ceff;
-    --ifm-color-primary-lightest: #a9e0ff;
+    --ifm-color-primary: #00a2ff;
+    --ifm-color-primary-dark: #0092e6;
+    --ifm-color-primary-darker: #008ad9;
+    --ifm-color-primary-darkest: #0071b3;
+    --ifm-color-primary-light: #1aabff;
+    --ifm-color-primary-lighter: #26b0ff;
+    --ifm-color-primary-lightest: #4dbeff;
   }
 
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -6,14 +6,16 @@
  /**
  * Colors extracted from our OpenRefine logo
  */
+
+ /* Primary color meets WCAG AA contrast ratio of 4.5:1 */
  :root {
-    --ifm-color-primary: #00a0ff;
-    --ifm-color-primary-dark: #0078ff;
-    --ifm-color-primary-darker: #0050ac;
-    --ifm-color-primary-darkest: #003b7e;
-    --ifm-color-primary-light: #00b4ff;
-    --ifm-color-primary-lighter: #2da6d1;
-    --ifm-color-primary-lightest: #00dcff;
+    --ifm-color-primary: #2272a0;
+    --ifm-color-primary-dark: #1f6790;
+    --ifm-color-primary-darker: #1d6188;
+    --ifm-color-primary-darkest: #185070;
+    --ifm-color-primary-light: #257db0;
+    --ifm-color-primary-lighter: #2783b8;
+    --ifm-color-primary-lightest: #2c94d0;
     --ifm-color-secondary: #999999;
     --ifm-alert-border-width: 0.375em;
     --ifm-alert-background-color: #ffffff;
@@ -21,6 +23,18 @@
     --ifm-panel-box-shadow-color: #999999;
     --ifm-code-color: var(--ifm-color-primary-darkest);
   }
+
+  [data-theme='dark'] {
+    --ifm-color-primary: #47bcff;
+    --ifm-color-primary-dark: #26b0ff;
+    --ifm-color-primary-darker: #16aaff;
+    --ifm-color-primary-darkest: #0091e4;
+    --ifm-color-primary-light: #68c8ff;
+    --ifm-color-primary-lighter: #78ceff;
+    --ifm-color-primary-lightest: #a9e0ff;
+  }
+
+
 
   /**
    * Size of youtube embeds


### PR DESCRIPTION
Fix #331

- Adjusts color ranges for Infirma to meet WCAG AA 4.5:1 contrast ratio
- Adds slightly lighter ranges for `dark` theme to meet as well.