### PR TITLE
Security announcement for 3.8.3

### DIFF
--- a/blog/2024-10-21-announcing-version-3-8-3.md
+++ b/blog/2024-10-21-announcing-version-3-8-3.md
@@ -1,0 +1,7 @@
+---
+author: Antonin Delpeuch
+title: "Important security fixes in upcoming 3.8.3 version"
+---
+
+On Thursday 24th October 2024, we will publish version 3.8.3 of OpenRefine, with fixes to a collection of important security vulnerabilities.
+Given the severity of those vulnerabilities, we encourage users to get ready to upgrade swiftly to this new version.


### PR DESCRIPTION
Given that we are going to patch severe vulnerabilities in 3.8.3, I think it could be worth pre-announcing the release. I've picked 24th October 2024 as release date, but it can be changed of course.