### PR TITLE
Update running.md to add Google Data JVM preferences

### DIFF
--- a/docs/manual/running.md
+++ b/docs/manual/running.md
@@ -214,6 +214,9 @@ Some of the most common keys (with their defaults) are:
 |Port|`-Drefine.port`|3333
 |The application folder|`-Drefine.webapp`|main/webapp
 |New version notice|`-Drefine.display.new.version.notice`|true
+|Google Data Client ID|`-Dext.gdata.clientid=<yourid>`|
+|Google Data Client secret|`-Dext.gdata.clientsecret=…`|
+|Google Data API Key|`-Dext.gdata.apikey=…`|
 
 
 The syntax is as follows:


### PR DESCRIPTION
As per instructions in the web page https://github.com/OpenRefine/OpenRefine/wiki/Google-Extension#missing-credentials.

This seems to be missing.

Regards, Antoine