### PR TITLE
Create 2024-10-30-openrefine-developer-role.md

### DIFF
--- a/blog/2024-10-30-openrefine-developer-role.md
+++ b/blog/2024-10-30-openrefine-developer-role.md
@@ -12,7 +12,7 @@ title: "Now Hiring: OpenRefine Developer"
 
 ## Role Summary
 
-This part-time role for an OpenRefine Developer, contracted through [Code for Science & Society Inc.](https://www.codeforsociety.org/) (a 501(c)(3) charitable organization in the USA), will focus on enhancing OpenRefine's stability, reliability, and quality to support the project’s long-term sustainability. This role is funded by the [EOSS-5 grant](/funding#2022-eoss-5), with additional funding potentially provided by the [Wikimedia General Support Fund](/funding#2024-wikimedia-foundation) (pending approval).
+This part-time role for an OpenRefine Developer, contracted through [Code for Science & Society Inc.](https://www.codeforsociety.org/) (a 501(c)(3) charitable organization in the USA), will focus on enhancing OpenRefine's stability, reliability, and quality to support the project’s long-term sustainability. This role is funded by the [EOSS-5 grant](/funding#2022-eoss-5).
 
 Key responsibilities include bug fixes, quality improvements, and ongoing maintenance, with an emphasis on features supported by grant funding. Over time, the developer will expand into release management, security maintenance, and mentorship within internship programs (e.g., GSoC, Outreachy).
 
@@ -20,9 +20,7 @@ Key responsibilities include bug fixes, quality improvements, and ongoing mainte
 * **Bug Fixes & Quality Improvements**
   * Prioritize and address bugs within the codebase to enhance stability and performance.
   * Improve reproducibility features (per EOSS-5 grant requirements).
-  * Maintain Wikimedia-related extensions, optimizing for stability and user experience (pending grant approval).
   * Implement quality improvements through refactoring, optimization, and code maintenance.
-  * Improvements through refactoring, optimization, and code maintenance.
 * **Community Support & Engagement**
   * Participate in community forums to support OpenRefine users and volunteers, fostering a positive and engaged user community.
 * **Pull Request Reviews & Ticket Triage**

--- a/blog/2024-10-30-openrefine-developer-role.md
+++ b/blog/2024-10-30-openrefine-developer-role.md
@@ -37,13 +37,15 @@ Key responsibilities include bug fixes, quality improvements, and ongoing mainte
 
 ## Work Environment & Reporting Structure
 
-This is a fully remote role with flexible working hours, allowing the developer to organize their time freely over the month. The OpenRefine Developer will primarily work with volunteers, including members of the Advisory Committee and most technical contributors. The OpenRefine community collaborates asynchronously through public forums and GitHub, accommodating the diverse time zones and work patterns of contributors. Occasional travel may be expected to attend relevant conferences and meetings, enabling valuable in-person engagement with the OpenRefine community and the broader open-source ecosystem.
+This is a fully remote role with flexible working hours, allowing the developer to organize their time freely over the month. This role requires a self-motivated, independent approach, with minimal direct supervision. The OpenRefine Developer will primarily work with volunteers, including members of the Advisory Committee and most technical contributors. The OpenRefine community collaborates asynchronously through public forums and GitHub, accommodating the diverse time zones and work patterns of contributors. Occasional travel may be expected to attend relevant conferences and meetings, enabling valuable in-person engagement with the OpenRefine community and the broader open-source ecosystem.
 
-The developer will report to the Project Manager, which will guide project goals and prioritization. For technical supervision and mentorship, the developer will collaborate closely with the OpenRefine Committer Group—comprising both volunteer contributors and paid contractors—to facilitate their integration with the codebase and OpenRefine’s development standards.
+The developer will report to the Project Manager, who will provide guidance on project goals and prioritization. Additionally, the OpenRefine Advisory Committee will serve as a resource for the developer. This committee assists with the administrative aspects of the role in collaboration with Code for Science & Society Inc. Weekly check-ins with the Advisory Committee and Project Manager will give the OpenRefine Developer the chance to report back on their work, gain an understanding of OpenRefine’s broader objectives, and receive ongoing support as needed.
 
-This role requires a self-motivated, independent approach, with minimal direct supervision. Weekly check-ins with the Advisory Committee and Project Manager will provide alignment with OpenRefine’s broader objectives and ongoing support as needed.
+For technical supervision and mentorship, the developer will work closely with the OpenRefine Committer Group, which consists of both volunteer contributors and paid contractors. This collaboration will help the developer integrate into the codebase and adhere to OpenRefine's development standards. The Committer Group is responsible for setting the project's technical roadmap and reviewing merge requests.
 
 ## Skills 
+
+Required:
 * **Java Proficiency**: As OpenRefine’s core codebase is Java, strong experience in Java is crucial.
 * **Web Development**: Familiarity with HTML, JavaScript, and CSS for front-end adjustments and minor feature development.
 * **Git and GitHub Expertise**: Proficient with Git for version control and GitHub workflows (pull request reviews, branch management, release workflows).
@@ -51,7 +53,7 @@ This role requires a self-motivated, independent approach, with minimal direct s
 * **Community-Driven and Collaborative**: Experience engaging constructively in a collaborative, open-source environment.
 * **Effective Communication**: Strong written communication skills for explaining technical concepts clearly to community members, volunteers, and contributors.
 
-Nice to have
+Nice to have:
 * **Open-Source Experience**: Prior contributions to or maintenance of open-source projects.
 * **Release Management Familiarity**: Some experience with release processes, ideally including automated build and deployment systems.
 * **Data Processing Knowledge**: Familiarity with data cleaning, transformation, or processing concepts relevant to OpenRefine’s core use cases.

--- a/blog/2024-10-30-openrefine-developer-role.md
+++ b/blog/2024-10-30-openrefine-developer-role.md
@@ -25,17 +25,17 @@ Key responsibilities include bug fixes, quality improvements, and ongoing mainte
   * Participate in community forums to support OpenRefine users and volunteers, fostering a positive and engaged user community.
 * **Pull Request Reviews & Ticket Triage**
   * Once familiar with the codebase, actively engage with community-submitted pull requests, providing constructive feedback and participating in collaborative review processes.
-  * Assist with ticket triage to identify and prioritize key issues and opportunities.
+  * Assist with issue triage to identify and prioritize project goals and opportunities.
 * **Progressive Onboarding into Release Management & Security Updates**
   * Upon receiving commit privileges, assist in merging pull requests to support the workflow of community contributions.
   * Take on Release Manager responsibilities to prepare and publish new releases, coordinating with the community on release planning.
   * With further onboarding, address security advisories and implement required updates and patches to maintain OpenRefine’s security.
 * **Internship Program Participation**
-  * Support programs such as Google Summer of Code (GSoC) and Outreachy, mentoring interns, reviewing their contributions, and fostering a supportive learning environment.
+  * Support programs, such as Google Summer of Code (GSoC) and Outreachy, by mentoring interns, reviewing their contributions, and fostering a supportive learning environment.
 
 ## Work Environment & Reporting Structure
 
-This is a fully remote role with flexible working hours, allowing the developer to organize their time freely over the month. This role requires a self-motivated, independent approach, with minimal direct supervision. The OpenRefine Developer will primarily work with volunteers, including members of the Advisory Committee and most technical contributors. The OpenRefine community collaborates asynchronously through public forums and GitHub, accommodating the diverse time zones and work patterns of contributors. Occasional travel may be expected to attend relevant conferences and meetings, enabling valuable in-person engagement with the OpenRefine community and the broader open-source ecosystem.
+This is a fully remote role with flexible working hours, allowing the developer to organize their time freely over each month. This role requires a self-motivated, independent approach, with minimal direct supervision. The OpenRefine Developer will primarily work with volunteers, including members of the Advisory Committee and most technical contributors. The OpenRefine community collaborates asynchronously through public forums and GitHub, accommodating the diverse time zones and work patterns of contributors. Occasional travel may be expected to attend relevant conferences and meetings, enabling valuable in-person engagement with the OpenRefine community and the broader open-source ecosystem.
 
 The developer will report to the Project Manager, who will provide guidance on project goals and prioritization. Additionally, the OpenRefine Advisory Committee will serve as a resource for the developer. This committee assists with the administrative aspects of the role in collaboration with Code for Science & Society Inc. Weekly check-ins with the Advisory Committee and Project Manager will give the OpenRefine Developer the chance to report back on their work, gain an understanding of OpenRefine’s broader objectives, and receive ongoing support as needed.
 

--- a/blog/2024-10-30-openrefine-developer-role.md
+++ b/blog/2024-10-30-openrefine-developer-role.md
@@ -39,7 +39,7 @@ Key responsibilities include bug fixes, quality improvements, and ongoing mainte
 
 This is a fully remote role with flexible working hours, allowing the developer to organize their time freely over the month. The OpenRefine Developer will primarily work with volunteers, including members of the Advisory Committee and most technical contributors. The OpenRefine community collaborates asynchronously through public forums and GitHub, accommodating the diverse time zones and work patterns of contributors. Occasional travel may be expected to attend relevant conferences and meetings, enabling valuable in-person engagement with the OpenRefine community and the broader open-source ecosystem.
 
-The developer will report to the OpenRefine Advisory Committee, which will guide project goals and prioritization. For technical supervision and mentorship, the developer will collaborate closely with the OpenRefine Committer Group—comprising both volunteer contributors and paid contractors—to facilitate their integration with the codebase and OpenRefine’s development standards.
+The developer will report to the Project Manager, which will guide project goals and prioritization. For technical supervision and mentorship, the developer will collaborate closely with the OpenRefine Committer Group—comprising both volunteer contributors and paid contractors—to facilitate their integration with the codebase and OpenRefine’s development standards.
 
 This role requires a self-motivated, independent approach, with minimal direct supervision. Weekly check-ins with the Advisory Committee and Project Manager will provide alignment with OpenRefine’s broader objectives and ongoing support as needed.
 

--- a/blog/2024-10-30-openrefine-developer-role.md
+++ b/blog/2024-10-30-openrefine-developer-role.md
@@ -1,0 +1,63 @@
+---
+author: Martin Magdinier
+title: "Now Hiring: OpenRefine Developer"
+---
+## About the role 
+
+* Role: Software Developer
+* Job Type: Part-Time Contract
+* Duration: 9 months with possible extension.
+* Job Location: Remote
+* Total funding available for the position: USD 90,000 annually 
+
+## Role Summary
+
+This part-time role for an OpenRefine Developer, contracted through [Code for Science & Society Inc.](https://www.codeforsociety.org/) (a 501(c)(3) charitable organization in the USA), will focus on enhancing OpenRefine's stability, reliability, and quality to support the project’s long-term sustainability. This role is funded by the [EOSS-5 grant](/funding#2022-eoss-5), with additional funding potentially provided by the [Wikimedia General Support Fund](/funding#2024-wikimedia-foundation) (pending approval).
+
+Key responsibilities include bug fixes, quality improvements, and ongoing maintenance, with an emphasis on features supported by grant funding. Over time, the developer will expand into release management, security maintenance, and mentorship within internship programs (e.g., GSoC, Outreachy).
+
+## Core Responsibilities
+* **Bug Fixes & Quality Improvements**
+  * Prioritize and address bugs within the codebase to enhance stability and performance.
+  * Improve reproducibility features (per EOSS-5 grant requirements).
+  * Maintain Wikimedia-related extensions, optimizing for stability and user experience (pending grant approval).
+  * Implement quality improvements through refactoring, optimization, and code maintenance.
+  * Improvements through refactoring, optimization, and code maintenance.
+* **Community Support & Engagement**
+  * Participate in community forums to support OpenRefine users and volunteers, fostering a positive and engaged user community.
+* **Pull Request Reviews & Ticket Triage**
+  * Once familiar with the codebase, actively engage with community-submitted pull requests, providing constructive feedback and participating in collaborative review processes.
+  * Assist with ticket triage to identify and prioritize key issues and opportunities.
+* **Progressive Onboarding into Release Management & Security Updates**
+  * Upon receiving commit privileges, assist in merging pull requests to support the workflow of community contributions.
+  * ake on Release Manager responsibilities to prepare and publish new releases, coordinating with the community on release planning.
+  * With further onboarding, address security advisories and implement required updates and patches to maintain OpenRefine’s security.
+* **Internship Program Participation**
+  * Support programs such as Google Summer of Code (GSoC) and Outreachy, mentoring interns, reviewing their contributions, and fostering a supportive learning environment.
+
+## Work Environment & Reporting Structure
+
+This is a fully remote role with flexible working hours, allowing the developer to organize their time freely over the month. The OpenRefine Developer will primarily work with volunteers, including members of the Advisory Committee and most technical contributors. The OpenRefine community collaborates asynchronously through public forums and GitHub, accommodating the diverse time zones and work patterns of contributors. Occasional travel may be expected to attend relevant conferences and meetings, enabling valuable in-person engagement with the OpenRefine community and the broader open-source ecosystem.
+
+The developer will report to the OpenRefine Advisory Committee, which will guide project goals and prioritization. For technical supervision and mentorship, the developer will collaborate closely with the OpenRefine Committer Group—comprising both volunteer contributors and paid contractors—to facilitate their integration with the codebase and OpenRefine’s development standards.
+
+This role requires a self-motivated, independent approach, with minimal direct supervision. Weekly check-ins with the Advisory Committee and Project Manager will provide alignment with OpenRefine’s broader objectives and ongoing support as needed.
+
+## Skills 
+* **Java Proficiency**: As OpenRefine’s core codebase is Java, strong experience in Java is crucial.
+* **Web Development**: Familiarity with HTML, JavaScript, and CSS for front-end adjustments and minor feature development.
+* **Git and GitHub Expertise**: Proficient with Git for version control and GitHub workflows (pull request reviews, branch management, release workflows).
+* **Self-Motivated and Adaptable**: Comfortable working independently in a remote setting, with a proactive approach to problem-solving.
+* **Community-Driven and Collaborative**: Experience engaging constructively in a collaborative, open-source environment.
+* **Effective Communication**: Strong written communication skills for explaining technical concepts clearly to community members, volunteers, and contributors.
+
+Nice to have
+* **Open-Source Experience**: Prior contributions to or maintenance of open-source projects.
+* **Release Management Familiarity**: Some experience with release processes, ideally including automated build and deployment systems.
+* **Data Processing Knowledge**: Familiarity with data cleaning, transformation, or processing concepts relevant to OpenRefine’s core use cases.
+
+## Hiring Process 
+
+We invite applicants to send their CV and a short motivation statement at hiring@openrefine.org. Applications will be reviewed on a rolling basis until the position is filled.
+
+_OpenRefine is fiscally sponsored by Code for Science and Society (CS&S). CS&S is an equal-opportunity employer committed to hiring a diverse workforce at all levels of the organization, thereby creating a culture that allows us to better serve our clientele, our employees, and our communities. We value and encourage the contributions of our colleagues and strive to create an environment where everyone can reach their full potential and drive outstanding results. All qualified applicants will receive consideration for employment without regard to race, national origin, age, sex, religion, disability, sexual orientation, marital status, veteran status, gender identity or expression, or any other basis protected by local, state, or federal law. This policy applies with regard to all aspects of one's employment, including hiring, transfer, promotion, compensation, eligibility for benefits, and termination._

--- a/blog/2024-10-30-openrefine-developer-role.md
+++ b/blog/2024-10-30-openrefine-developer-role.md
@@ -30,7 +30,7 @@ Key responsibilities include bug fixes, quality improvements, and ongoing mainte
   * Assist with ticket triage to identify and prioritize key issues and opportunities.
 * **Progressive Onboarding into Release Management & Security Updates**
   * Upon receiving commit privileges, assist in merging pull requests to support the workflow of community contributions.
-  * ake on Release Manager responsibilities to prepare and publish new releases, coordinating with the community on release planning.
+  * Take on Release Manager responsibilities to prepare and publish new releases, coordinating with the community on release planning.
   * With further onboarding, address security advisories and implement required updates and patches to maintain OpenRefine’s security.
 * **Internship Program Participation**
   * Support programs such as Google Summer of Code (GSoC) and Outreachy, mentoring interns, reviewing their contributions, and fostering a supportive learning environment.


### PR DESCRIPTION
Following the conversation on the forum https://forum.openrefine.org/t/seeking-input-on-new-developer-role-for-openrefine/1756    here is a draft job description for the developer role we want to hire for 2025. I am opening directly as PR to increase visibility with other developers on the project. 

As mentioned in the forum, I can lead the process (job posting, resume triaging, outreach, scheduling, and performing non-technical interviews). For other hired roles, members of the Advisory Committee participated in some interviews. I would be more comfortable if a senior developer were involved in the process to validate technical skills of the candidate. 