### PR TITLE
added sitemap to plugins which include lastmod for improving SEO#276

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -16,6 +16,19 @@ return {
   organizationName: 'OpenRefine', // Usually your GitHub org/user name.
   projectName: 'openrefine.github.com', // Usually your repo name.
   themes: ['@docusaurus/theme-mermaid'],
+  plugins: [
+    './src/plugins/docusaurus-versionsjson-plugin',
+    [
+      '@docusaurus/plugin-sitemap',
+      {
+        lastmod: 'date',
+        changefreq: 'weekly',
+        priority: 0.5, // Default priority for all pages
+        ignorePatterns: ['/tags/**'], // Ignore specific patterns
+        filename: 'sitemap.xml',
+      },
+    ],
+  ],
   themeConfig: {
     navbar: {
       title: 'OpenRefine',
@@ -174,7 +187,6 @@ return {
       copyright: `<a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/80x15.png" /></a><br />OpenRefine's website and documentation is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.`,
     },
   },
-  plugins: ['./src/plugins/docusaurus-versionsjson-plugin'],
   presets: [
     [
       '@docusaurus/preset-classic',
@@ -202,6 +214,7 @@ return {
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
+        sitemap: false,
       },
     ],
   ],

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "^3.3.2",
+    "@docusaurus/plugin-sitemap": "^3.6.3",
     "@docusaurus/preset-classic": "^3.3.2",
     "@docusaurus/theme-mermaid": "^3.3.2",
     "@mdx-js/react": "^3.0.0",


### PR DESCRIPTION
PR for Issue #276

This PR addresses the addition of the lastmod field to the sitemap. After applying these changes, the generated sitemap.xml (accessible at /sitemap.xml) will look as follows:


<img width="733" alt="Screenshot 2024-11-26 at 7 25 07 PM" src="https://github.com/user-attachments/assets/76053abb-4ee8-4f49-8bfa-7fd84fe98d9c">
