### PR TITLE
added sitemap to docusaurus.config.js file and also added missing serve script in the package.json#276

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -179,6 +179,13 @@ return {
     [
       '@docusaurus/preset-classic',
       {
+        sitemap: {
+          lastmod: 'date',
+          changefreq: 'weekly',
+          priority: 0.5,
+          ignorePatterns: ['/tags/**'],
+          filename: 'sitemap.xml',
+        },
         docs: {
           // Docs folder path relative to website dir. Equivalent to `customDocsPath`.
           // path: 'docs',

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "start": "docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
+    "serve": "docusaurus serve",
     "deploy": "docusaurus deploy",
     "netlify:build:production": "yarn build",
     "netlify:build:deployPreview": "yarn build"
@@ -31,5 +32,5 @@
   "engines": {
     "node": ">=18.0"
   },
-  "packageManager": "yarn@4.5.2"
+  "packageManager": "yarn@4.5.3"
 }


### PR DESCRIPTION
PR for Issue https://github.com/OpenRefine/openrefine.org/issues/276

This PR addresses the addition of the lastmod field to the sitemap. After applying these changes, the generated sitemap.xml (accessible at /sitemap.xml) will look as follows:

<img width="733" alt="Screenshot 2024-11-26 at 7 25 07 PM" src="https://github.com/user-attachments/assets/54338bd3-626b-44e0-9ff2-c8fa10ca8b14">

