### PR TITLE
add mission vision value page

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -127,6 +127,10 @@ return {
           title: 'About OpenRefine',
           items: [
             {
+              label: 'Mission and Vision',
+              href: '/mission_vision',
+            },
+            {
               label: 'Project history',
               href: '/openrefine_history',
             },

--- a/src/pages/mission_vision.md
+++ b/src/pages/mission_vision.md
@@ -1,0 +1,50 @@
+---
+title: OpenRefine Mission and Vision
+description: OpenRefine Mission and Vision
+hide_table_of_contents: true
+---
+
+## OpenRefine Vision
+ 
+A more informed world where working with data is easy and engaging
+
+
+
+
+## OpenRefine Mission
+
+Empowering everyone to meaningfully engage with data by providing an accessible open source tool and nurturing a diverse, supportive community.
+
+
+## OpenRefine Values 
+
+We recognize that building and supporting a tool that meets the important vision and mission of OpenRefine necessitates a values-driven community. The values below refer to the community’s core principles and ethics. These values directly map onto the principles embedded into the tool itself and are reected in how OpenRefine, the tool, is conceptualized, built, maintained, taught, and used.
+
+* Respectful of Diverse Backgrounds & Expertise
+* Approachable
+* Transparent & Open
+* Curious
+* Community-driven
+
+
+
+### Respectful of Diverse Backgrounds & Expertise
+
+We celebrate that people come to the OpenRefine tool and community from varying backgrounds, identities, technical abilities, geographies, privileges, industries, linguistic backgrounds, and more. We honor the experiences of our users and contributors and aim to develop features and training that encourage and nourish diverse engagement with the tool, prioritizing accessibility and usability to broaden reach and impact.
+
+
+### Approachable
+
+We ensure that OpenRefine is inviting and supportive of all participants by providing various on-ramps to engagement with the tool and community, including but not limited to clear documentation, thoughtful mentorship and training, and by prioritizing ease-of-use and participation across backgrounds and skill-levels. We expect everyone to engage with kindness, warmth, patience, and an unwavering commitment to mutual support.
+
+### Transparent & Open
+
+We create pathways for and encourage clear communication and knowledge-sharing, ranging from regularly-updated documentation to consistent public participation in community forums. We believe that transparent practices are essential to a collaborative community where all participants – including those with limited time and experience – are informed and feel empowered to engage. The tool mirrors this commitment to transparency through prioritizing the use of open and commons-based data, and the privacy of all users
+
+### Curious
+
+We believe in the importance of a learning mindset, where everyone leads with questions and engages with humility. We recognize that we have a lot to learn from one another, and seek opportunities to foster our mutual growth. This includes being thoughtful in how we give and receive feedback, consistently examining our own biases, and providing proactive support to new learners in our community. For the tool itself, we operate with humility and listen to end-users to prioritize their needs and plan for features and iterations that optimize their use of the tool.
+
+### Community-driven
+
+We seek to facilitate a sense of community among users and contributors, and to prioritize the perspectives of community members in key decisions. We believe that our users and contributors dene OpenRefine, and should collaboratively drive our work forward – not as individuals but as members of a supportive and vibrant community. This is reected in open communication about the future of the community and tool, a sense of agency among community members, and in democratic decision-making around strategic and technical priorities.

--- a/src/pages/mission_vision.md
+++ b/src/pages/mission_vision.md
@@ -6,7 +6,7 @@ hide_table_of_contents: true
 
 ## OpenRefine Vision
  
-A more informed world where working with data is easy and engaging
+A more informed world where working with data is easy and engaging.
 
 
 
@@ -39,7 +39,7 @@ We ensure that OpenRefine is inviting and supportive of all participants by prov
 
 ### Transparent & Open
 
-We create pathways for and encourage clear communication and knowledge-sharing, ranging from regularly-updated documentation to consistent public participation in community forums. We believe that transparent practices are essential to a collaborative community where all participants – including those with limited time and experience – are informed and feel empowered to engage. The tool mirrors this commitment to transparency through prioritizing the use of open and commons-based data, and the privacy of all users
+We create pathways for and encourage clear communication and knowledge-sharing, ranging from regularly-updated documentation to consistent public participation in community forums. We believe that transparent practices are essential to a collaborative community where all participants – including those with limited time and experience – are informed and feel empowered to engage. The tool mirrors this commitment to transparency through prioritizing the use of open and commons-based data, and the privacy of all users.
 
 ### Curious
 
@@ -47,4 +47,4 @@ We believe in the importance of a learning mindset, where everyone leads with qu
 
 ### Community-driven
 
-We seek to facilitate a sense of community among users and contributors, and to prioritize the perspectives of community members in key decisions. We believe that our users and contributors dene OpenRefine, and should collaboratively drive our work forward – not as individuals but as members of a supportive and vibrant community. This is reected in open communication about the future of the community and tool, a sense of agency among community members, and in democratic decision-making around strategic and technical priorities.
+We seek to facilitate a sense of community among users and contributors, and to prioritize the perspectives of community members in key decisions. We believe that our users and contributors define OpenRefine, and should collaboratively drive our work forward – not as individuals but as members of a supportive and vibrant community. This is reflected in open communication about the future of the community and tool, a sense of agency among community members, and in democratic decision-making around strategic and technical priorities.


### PR DESCRIPTION
This PR adds the results of the work to clarify OpenRefine's Mission, Vision, and Values following the project completed in 2024. see the [related discussion on the forum](https://forum.openrefine.org/t/feedback-request-on-openrefines-draft-vision-mission-values/1619/8). 

The integration in the website was previously discussed in #291 and on the [forum](https://forum.openrefine.org/t/requesting-feedback-documenting-openrefine-community-handbooks/1224/2)
