### PR TITLE
Homebrew updates no longer need to be triggered manually

### DIFF
--- a/docs/technical-reference/homebrew-cask-process.md
+++ b/docs/technical-reference/homebrew-cask-process.md
@@ -4,11 +4,11 @@ title: Maintaining OpenRefine's Homebrew cask
 sidebar_label: Maintaining OpenRefine's Homebrew cask
 ---
 
-[Homebrew](https://brew.sh) is a popular command-line package manager for macOS. Once Homebrew is installed, OpenRefine can be installed via the simple command, `brew install openrefine`. OpenRefine's presence on Homebrew is found in the Homebrew Cask repository project, as a "cask", at https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/openrefine.rb.
+[Homebrew](https://brew.sh) is a popular command-line package manager for macOS. Once Homebrew is installed, OpenRefine can be installed via the simple command, `brew install openrefine`. OpenRefine's presence on Homebrew is found in the Homebrew Cask repository project, as a "cask", at https://github.com/Homebrew/homebrew-cask/blob/master/Casks/o/openrefine.rb.
 
 **Terminology:** "Homebrew Cask" is the segment of Homebrew where pre-built binaries and GUI applications go, whereas the original "Homebrew" project is reserved for command-line utilities that can be built from source. Because the macOS version of OpenRefine is released as an app bundle with GUI components, it is handled as a Homebrew Cask.
 
-When there is a new release of OpenRefine, registering the new release with Homebrew can be easily accomplished using Homebrew's `brew bump-cask-pr` command. Full directions for this utility as well as procedures for more complex PRs can be found on [the Homebrew Cask CONTRIBUTING page](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md), but, a simple version bump is a one-line command. For example, to update Homebrew's version of OpenRefine to 3.4.1, use this command:
+When there is a new release of OpenRefine, registering the new release with Homebrew can be easily accomplished using Homebrew's `brew bump-cask-pr` command (if it's not done automatically as in [this PR](https://github.com/Homebrew/homebrew-cask/pull/192923)). Full directions for this utility as well as procedures for more complex PRs can be found on [the Homebrew Cask CONTRIBUTING page](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md), but, a simple version bump is a one-line command. For example, to update Homebrew's version of OpenRefine to 3.4.1, use this command:
 
 ```
 brew bump-cask-pr --version 3.4.1 openrefine

--- a/docs/technical-reference/version-release-process.md
+++ b/docs/technical-reference/version-release-process.md
@@ -16,10 +16,9 @@ git tag -a -m "Second beta" 2.6-beta.2
 ```
 5. Create a GitHub release based on that tag, with a summary of the changes as description of the release. Publishing the GitHub release will trigger the generation of the packaged artifacts, which will be added to the release on GitHub. Note that if you create a draft release and then publish it, it may not trigger the release workflow on Github Actions.
 6. Once the artifacts are ready, update the [`releases.json`](https://github.com/OpenRefine/openrefine.org/blob/master/releases.json) file in the openrefine.org repository to reflect this new version. Verify that the correct versions are shown at [http://openrefine.org/download](http://openrefine.org/download)
-7. [Update the OpenRefine Homebrew cask](https://openrefine.org/docs/technical-reference/homebrew-cask-process) or coordinate an update via the [developer forum](https://forum.openrefine.org/c/dev/8)
-8. Announce on the [announcements section of the OpenRefine forum](https://forum.openrefine.org/c/news/13), or even on the [blog](https://openrefine.org/blog) if this is a major release (the blog is imported automatically into the announcements category
+7. Announce on the [announcements section of the OpenRefine forum](https://forum.openrefine.org/c/news/13), or even on the [blog](https://openrefine.org/blog) if this is a major release (the blog is imported automatically into the announcements category
     of the forum)
-9. Update the version in master to the next version number with `-SNAPSHOT` (such as `4.3-SNAPSHOT`), in the same places as in step 2.
+8. Update the version in master to the next version number with `-SNAPSHOT` (such as `4.3-SNAPSHOT`), in the same places as in step 2.
 
 Apple code signing
 ==================


### PR DESCRIPTION
This removes one step from the release process, as Homebrew updates seem to be automated and don't require any action on our side. Yay!