### PR TITLE
Set version to 3.9.3

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -1,8 +1,8 @@
 [
     {
-        "version": "3.9.2",
+        "version": "3.9.3",
         "stable": true,
-        "date": "2025-03-26",
+        "date": "2025-04-17",
         "source": "github",
         "artifacts": [
              {


### PR DESCRIPTION
Now that version 3.9.3 has build artifacts attached to the GitHub release, I am updating the releases JSON file to point to the new latest version.