### PR TITLE
add funding.json and backer page

### DIFF
--- a/src/pages/backers.md
+++ b/src/pages/backers.md
@@ -1,9 +1,9 @@
 ---
-title: OpenRefine Benefactors
+title: OpenRefine Backers
 description: Your donations help further develop and maintain OpenRefine.
 hide_table_of_contents: false
 ---
-# OpenRefine Benefactors 
+# OpenRefine Backers 
 
 Thank you for supporting OpenRefine in 2025! We are proud to list your name on this page, which celebrates everyone who made a financial contribution to OpenRefine at any level. 
 

--- a/src/pages/benefactors.md
+++ b/src/pages/benefactors.md
@@ -1,0 +1,56 @@
+---
+title: OpenRefine Benefactors
+description: Your donations help further develop and maintain OpenRefine.
+hide_table_of_contents: false
+---
+# OpenRefine Benefactors 
+
+Thank you for supporting OpenRefine in 2025! We are proud to list your name on this page, which celebrates everyone who made a financial contribution to OpenRefine at any level. 
+
+This page reflects gifts received after December 1, 2024. 2024 donors are listed in our [2024 Year In Review post](/blog/2024/12/13/year-in-review-2024#2024-donor-shoutouts).
+  
+You can [donate here](/donate)
+
+## Champion Level
+At least $10,000 donated in 2025. Sponsor the entire team for one month
+
+## Patron Level
+Between $5,000 and $10,000 donated in 2025. Support our core team for two weeks
+
+## Partner Level
+Between $2,500 and $5,000 donated in 2025. Support our core team for one week
+* Vanguard Charitable (one-time)
+
+## Advocate Plus Level
+Between $1,000 and $2,500 donated in 2025. Help us attend two conferences to promote OpenRefine
+
+## Advocate Level
+Between $500 and $1,000 donated in 2025. Help us attend a conference to promote OpenRefine
+
+## Benefactor Level
+Between $100 and $500 donated in 2025. Pay for third-party tools and services for one month
+* RefinePro (recurring)
+
+## Infrastructure Sponsor Level
+Between $50 and $100 donated in 2025. Fund our forum hosting for one month
+* ostephens (recurring)
+## Sponsor Level
+Between $25 and $50 donated in 2025. Fund our Figma license for one month
+* DaxServer (recurring)
+* alanorth (recurring)
+
+## Sustainer Plus Level
+Between $10 and $25 donated in 2025. Contribute toward maintaining the OpenRefine infrastructure
+* timtomch (recurring)
+* trantor (recurring)
+* wetneb (recurring)
+
+## Sustainer Level
+Between $5 and $10 donated in 2025. Contribute toward maintaining the OpenRefine infrastructure
+* EstebanMH-SiB (recurring)
+
+## Supporter
+Less than $5 donated in 2025. Show your support for keeping OpenRefine maintained
+* btseee  (one-time)
+
+Help us reach our funding goal, [donate here](/donate)

--- a/src/pages/donate.md
+++ b/src/pages/donate.md
@@ -4,14 +4,35 @@ description: Your donations help further develop and maintain OpenRefine.
 hide_table_of_contents: true
 ---
 
-# Give to OpenRefine
+# Support OpenRefine
+## Why Your Support Matters
 
-Your donations help further maintain and further develop OpenRefine. Thank you for your support!
+OpenRefine is a free, power tool for working with messy data and improving it. Our mission is to empower everyone to meaningfully engage with data by providing an accessible, open-source tool and nurturing a diverse, supportive community. Your sponsorship fills the funding gap beyond grants, ensuring the project remains healthy and community-driven. You can make a one-time gift or become a monthly sponsor at any level.
 
-OpenRefine is a fiscally sponsored project of [Code for Science & Society Inc.](https://codeforscience.org). Donations are tax deductible to the extent allowed by law in the US. Tax ID 81-3791683.
+
+## Funding Tier
+We are funded by **grants and gifts from institutions and individuals** like you. Each month, we need **US \$11 500** to fully support our core team for maintenance, coordination, licensing, and administration. Details on fund usage and other sources of funding are available on our [Funding](/funding) page.
+
+Available funding tier are: 
+* **$5 Sustainer Level:** Contribute toward maintaining the OpenRefine infrastructure	
+* **$10 Sustainer Plus Level:** Contribute toward maintaining the OpenRefine infrastructure	
+* **$25 Sponsor Level:** Fund our Figma license for one month
+* **$50 Infrastructure Sponsor Level:** Fund our forum hosting for one month
+* **$100 Benefactor Level:** Pay for third-party tools and services for a month
+* **$500 Advocate Level:** Help us attend a conference to promote OpenRefine
+* **$1,000 Advocate Plus Level:** Help us attend two conferences to promote OpenRefine
+* **$2,500 Partner Level:** Support our core team for one week
+* **$5,000 Patron Level:** Support our core team for two weeks
+* **$10,000 Champion Level:** Sponsor the entire team for one month
+
+See our current [benefactors](/benefactors) and [active grants](/funding#current-grants)
 
 You can also support OpenRefine via <a href="https://github.com/sponsors/OpenRefine">GitHub Sponsors</a>.
 <script src="https://donorbox.org/widget.js" paypalExpress="true"></script><iframe src="https://donorbox.org/embed/open-refine" name="donorbox" allowpaymentrequest="allowpaymentrequest" seamless="seamless" frameborder="0" scrolling="yes" width="100%" style={{maxWidth: '500px', minWidth: '250px', minHeight: '750px', maxHeight: 'none!important'}}></iframe>
+
+OpenRefine is a fiscally sponsored project of [Code for Science & Society Inc.](https://codeforscience.org). Donations are tax deductible to the extent allowed by law in the US. Tax ID 81-3791683.
+
+
 
 
 

--- a/src/pages/donate.md
+++ b/src/pages/donate.md
@@ -11,7 +11,7 @@ OpenRefine is a free, power tool for working with messy data and improving it. O
 
 
 ## Funding Tier
-We are funded by **grants and gifts from institutions and individuals** like you. Each month, we need **US \$11 500** to fully support our core team for maintenance, coordination, licensing, and administration. Details on fund usage and other sources of funding are available on our [Funding](/funding) page.
+We are funded by **grants and gifts from institutions and individuals** like you. Our annual operating budget is US$140 000 (or appx US$11,500 per month) to support our core team for maintenance, coordination, licensing, and administration. Details on fund usage and other sources of funding are available on our [funding page](/funding).
 
 Available funding tier are: 
 * **$5 Sustainer Level:** Contribute toward maintaining the OpenRefine infrastructure	
@@ -25,7 +25,7 @@ Available funding tier are:
 * **$5,000 Patron Level:** Support our core team for two weeks
 * **$10,000 Champion Level:** Sponsor the entire team for one month
 
-See our current [benefactors](/benefactors) and [active grants](/funding#current-grants)
+See our current [backers](/backers) and [active grants](/funding#active-grants)
 
 You can also support OpenRefine via <a href="https://github.com/sponsors/OpenRefine">GitHub Sponsors</a>.
 <script src="https://donorbox.org/widget.js" paypalExpress="true"></script><iframe src="https://donorbox.org/embed/open-refine" name="donorbox" allowpaymentrequest="allowpaymentrequest" seamless="seamless" frameborder="0" scrolling="yes" width="100%" style={{maxWidth: '500px', minWidth: '250px', minHeight: '750px', maxHeight: 'none!important'}}></iframe>

--- a/src/pages/funding.json
+++ b/src/pages/funding.json
@@ -2,10 +2,10 @@
   "version": "v1.0.0",
   "entity": {
     "type": "organisation",
-    "role": "steward",
-    "name": "Martin Magdinier",
-    "email": "martin@openrefine.org",
-    "description": "OpenRefine is a free, powerful tool for working with messy data and improving it. Our mission is to empower everyone to meaningfully engage with data by providing an accessible open source tool and nurturing a diverse, supportive community.",
+    "role": "other",
+    "name": "OpenRefine",
+    "email": "contact@openrefine.org",
+    "description": "OpenRefine is a free, powerful tool for working with messy data and improving it. Our mission is to empower everyone to meaningfully engage with data by providing an accessible open source tool and nurturing a diverse, supportive community. OpenRefine is a fiscally sponsored project of Code for Science & Society, a 501(c)(3) charitable organization in the USA. Donations are tax-deductible to the extent allowed by US law (Tax ID: 81-3791683).",
     "webpageUrl": {
       "url": "https://openrefine.org",
       "wellKnown": "https://openrefine.org/.well-known/funding-manifest-urls"

--- a/src/pages/funding.json
+++ b/src/pages/funding.json
@@ -15,7 +15,7 @@
     {
       "guid": "openrefine",
       "name": "OpenRefine",
-      "description": "We are funded by grants and gifts from institutions and individuals like you. Our annual operating budget is US$140 000 (or appx US$11,500 per month) to support our core team for maintenance, coordination, licensing, and administration. Details on fund usage and other sources of funding are available on our funding page (https://openrefine.org/funding). We would like to thanks our current donors (https://openrefine.org/backers).",
+      "description": "OpenRefine is funded by grants and gifts from institutions and individuals like you. Our annual operating budget is US$140 000 (or appx US$11,500 per month) to support our core team for maintenance, coordination, licensing, and administration. Details on fund usage and other sources of funding are available on our funding page (https://openrefine.org/funding). We would like to thanks our current donors (https://openrefine.org/backers).",
       "webpageUrl": {
         "url": "https://openrefine.org"
       },

--- a/src/pages/funding.json
+++ b/src/pages/funding.json
@@ -1,0 +1,191 @@
+{
+  "version": "v1.0.0",
+  "entity": {
+    "type": "organisation",
+    "role": "steward",
+    "name": "Martin Magdinier",
+    "email": "martin@openrefine.org",
+    "description": "OpenRefine is a free, powerful tool for working with messy data and improving it. Our mission is to empower everyone to meaningfully engage with data by providing an accessible open source tool and nurturing a diverse, supportive community.",
+    "webpageUrl": {
+      "url": "https://openrefine.org",
+      "wellKnown": "https://openrefine.org/.well-known/funding-manifest-urls"
+    }
+  },
+  "projects": [
+    {
+      "guid": "openrefine",
+      "name": "OpenRefine",
+      "description": "We are funded by grants and gifts from institutions and individuals like you. Our annual operating budget is US$140 000 (or appx US$11,500 per month) to support our core team for maintenance, coordination, licensing, and administration. Details on fund usage and other sources of funding are available on our funding page (https://openrefine.org/funding). We would like to thanks our current donors (https://openrefine.org/backers).",
+      "webpageUrl": {
+        "url": "https://openrefine.org"
+      },
+      "repositoryUrl": {
+        "url": "https://github.com/OpenRefine/OpenRefine",
+        "wellKnown": "https://github.com/OpenRefine/OpenRefine/.well-known/funding-manifest-urls"
+      },
+      "licenses": [
+        "BSD-3"
+      ],
+      "tags": [
+        "reconciliation",
+        "wikidata",
+        "opendata",
+        "journalism",
+        "data-analysis",
+        "data-wrangling",
+        "datamining",
+        "datajournalism",
+        "datacleaning",
+        "datacleansing"
+      ]
+    }
+  ],
+  "funding": {
+    "channels": [
+      {
+        "guid": "github",
+        "type": "other",
+        "description": "https://github.com/sponsors/OpenRefine"
+      },
+      {
+        "guid": "website",
+        "type": "other",
+        "description": "https://openrefine.org/donate"
+      }
+    ],
+    "plans": [
+      {
+        "guid": "sustainer",
+        "status": "active",
+        "name": "$5/month - Sustainer Level",
+        "description": "Contribute toward maintaining the OpenRefine infrastructure",
+        "amount": 5,
+        "currency": "USD",
+        "frequency": "monthly",
+        "channels": [
+          "github",
+          "website"
+        ]
+      },
+      {
+        "guid": "sustainer-plus",
+        "status": "active",
+        "name": "$10/month - Sustainer Plus Level",
+        "description": "Contribute toward maintaining the OpenRefine infrastructure",
+        "amount": 10,
+        "currency": "USD",
+        "frequency": "monthly",
+        "channels": [
+          "github",
+          "website"
+        ]
+      },
+      {
+        "guid": "sponsor",
+        "status": "active",
+        "name": "$25/month - Sponsor Level",
+        "description": "Fund our Figma license for one month",
+        "amount": 25,
+        "currency": "USD",
+        "frequency": "monthly",
+        "channels": [
+          "github",
+          "website"
+        ]
+      },
+      {
+        "guid": "infrastructure-sponsor",
+        "status": "active",
+        "name": "$50/month - Infrastructure Sponsor Level",
+        "description": "Fund our forum hosting for one month",
+        "amount": 50,
+        "currency": "USD",
+        "frequency": "monthly",
+        "channels": [
+          "github",
+          "website"
+        ]
+      },
+      {
+        "guid": "benefactor",
+        "status": "active",
+        "name": "$100/month - Benefactor Level",
+        "description": "Pay for third-party tools and services for one month",
+        "amount": 100,
+        "currency": "USD",
+        "frequency": "monthly",
+        "channels": [
+          "github",
+          "website"
+        ]
+      },
+      {
+        "guid": "advocate",
+        "status": "active",
+        "name": "$500/month - Advocate Level",
+        "description": "Help us attend a conference to promote OpenRefine",
+        "amount": 500,
+        "currency": "USD",
+        "frequency": "monthly",
+        "channels": [
+          "github",
+          "website"
+        ]
+      },
+      {
+        "guid": "advocate-plus",
+        "status": "active",
+        "name": "$1,000/month - Advocate Plus Level",
+        "description": "Help us attend two conferences to promote OpenRefine",
+        "amount": 1000,
+        "currency": "USD",
+        "frequency": "monthly",
+        "channels": [
+          "github",
+          "website"
+        ]
+      },
+      {
+        "guid": "partner",
+        "status": "active",
+        "name": "$2,500/month - Partner Level",
+        "description": "Support our core team for one week",
+        "amount": 2500,
+        "currency": "USD",
+        "frequency": "monthly",
+        "channels": [
+          "github",
+          "website"
+        ]
+      },
+      {
+        "guid": "patron",
+        "status": "active",
+        "name": "$5,000/month - Patron Level",
+        "description": "Support our core team for two weeks",
+        "amount": 5000,
+        "currency": "USD",
+        "frequency": "monthly",
+        "channels": [
+          "github",
+          "website"
+        ]
+      },
+      {
+        "guid": "champion",
+        "status": "active",
+        "name": "$10,000/month - Champion Level",
+        "description": "Sponsor the entire team for one month",
+        "amount": 10000,
+        "currency": "USD",
+        "frequency": "monthly",
+        "channels": [
+          "github",
+          "website"
+        ]
+      }
+    ],
+    "history": []
+  }
+}
+

--- a/src/pages/funding.md
+++ b/src/pages/funding.md
@@ -30,7 +30,7 @@ OpenRefine is a fiscally sponsored project of [Code for Science & Society](https
 - [Online form](https://openrefine.org/donate) for Credit Card, PayPal, and Bank Transfer (up to USD 25,000)
 - Via Code for Science & Society from [their donation page](https://www.codeforsociety.org/donate) for larger donations.
 
-We would like to thanks our [current donors](/benefactors).
+We would like to thanks our [current donors](/backers).
 
 ## Grants
 

--- a/src/pages/funding.md
+++ b/src/pages/funding.md
@@ -1,20 +1,24 @@
 ---
-title: OpenRefine's funding sources
-description: OpenRefine seeks grants to support its work. Learn how individuals and organizations can financially contribute to further OpenRefine's mission.
+title: Funding
+description: How OpenRefine is financed—grants, institutional support, and community contributions
+hide_table_of_contents: false
 ---
 
-# OpenRefine's funding sources
+# Project Funding Overview
 
-OpenRefine relies on a combination of [volunteer contributions](/docs/technical-reference/contributing) and financial support to sustain its development.
+OpenRefine relies on a combination of volunteer contributions and financial support to sustain its development. This diversified funding keeps our core team in place, supports essential infrastructure, and enables strategic community outreach.
 
-We maintain a small paid team to ensure the project's long-term viability. The team includes:
-- One full-time developer
-- One part-time project manager
-- Other contractors as needed
+## Operating Budget
 
-Additionally, we utilize funds for internships, maintaining software subscriptions (e.g., Figma, Discourse, LimeSurvey), and the domain openrefine.org.
+We are seeking your support to fund OpenRefine's core team, a small group of part-time staff who maintain the project's infrastructure, respond to community needs, review and guide volunteer contributors, handle security reports, and steward the ecosystem of extensions and reconciliation services. 
 
-This page outlines our various sources of funding and how you can contribute financially.
+Our annual operating budget is **US$140 000** (or appx US$11,500 per month), covering:
+* US $7,500 per month for OpenRefine Developer & Contributor Engagement lead
+* US $2,500 per month for project coordination
+* US $70 per month for essential software licenses (Figma and Discourse)
+* 15% of donations to our fiscal sponsor, Code for Science and Society, to handle administration and compliance
+
+Additional funding enables us to organize community events, conduct outreach efforts, and undertake special projects. OpenRefine maintains a [curated list of goalposts](/docs/technical-reference/development-roadmap) based on the interests and priorities of our community. We are currently seeking resources to achieve them. You can help by forming partnerships between your organization and OpenRefine or providing financial support.
 
 ## Individual and corporate donations
 
@@ -25,6 +29,8 @@ OpenRefine is a fiscally sponsored project of [Code for Science & Society](https
 - [GitHub sponsorship](https://github.com/sponsors/OpenRefine)
 - [Online form](https://openrefine.org/donate) for Credit Card, PayPal, and Bank Transfer (up to USD 25,000)
 - Via Code for Science & Society from [their donation page](https://www.codeforsociety.org/donate) for larger donations.
+
+We would like to thanks our [current donors](/benefactors).
 
 ## Grants
 
@@ -46,7 +52,7 @@ If you're interested in partnering with us for a grant, [contact us](https://for
   * [Expression of Interest](/uploads/2025-Research-Software-Maintenance-Fund-EOI.pdf) 
   * [Forum thread](https://forum.openrefine.org/t/funding-opportunity-seeking-ukri-eligible-partner-for-research-software-maintenance-fund-application/2233)
 
-### Current grants
+### Active Grants
 
 OpenRefine is currently working on the following grants. 
 
@@ -198,4 +204,3 @@ We applied for the following grant opportunities, but our proposals were not sel
 * **Relevant links**: 
   * [Letter of intent](/uploads/2021-EOSS4-LOI.pdf)
   * [Grant application](/uploads/2021-EOSS4.pdf)
-  

--- a/static/.well-known/funding-manifest-urls
+++ b/static/.well-known/funding-manifest-urls
@@ -1,0 +1,1 @@
+https://openrefine.org/funding.json


### PR DESCRIPTION
This PR follows forum coversations in [Funding Opportunities – Q2 2025](https://forum.openrefine.org/t/funding-opportunities-q2-2025/2147). It updates how we promote the donation to OpenRefine by 
- Adding a **Backers** page at `/backers` to recognize everyone who has donated in 2025.  
- Adding more details regarding OpenRefine operating budget
- Introducing a **machine-readable** `funding.json` manifest at `/funding.json` and exposing it via `/.well-known/funding-manifest-urls` in compliance with the [funding.json v1.0.0 spec](https://fundingjson.org/).  
- Preparing us to list OpenRefine in the [FLOSS/fund directory](https://dir.floss.fund/) by supporting the new standard.

Next Steps 
- Merge this PR, then **update our GitHub Sponsors** page copy and tiers to match the new Donate page wording.  
- Validate the live manifest with the FLOSS.fund validator and submit our project to their directory.  