### PR TITLE
Add java artifact publishing section to release documentation

### DIFF
--- a/docs/technical-reference/version-release-process.md
+++ b/docs/technical-reference/version-release-process.md
@@ -58,3 +58,7 @@ We have code signing certificates for our iOS distributions. Those are available
 * Import this certificate in the "Keychain Access" app on your mac
 * The signing workflow can be found in `.github/workflows/snapshot_release.yml`
 
+Java artifact publishing
+========================
+
+Java artifacts are published to [the `org.openrefine` namespace in Maven Central](https://central.sonatype.com/artifact/org.openrefine/openrefine/overview). Core developer group members and community members with access to the `openrefinedev@gmail.com` account can contact Sonatype support to manage access to the namespace.


### PR DESCRIPTION
This is a small update, but given the recent issues with publishing snapshots I wanted to make sure that at least some point of contact was mentioned in the release process documentation (even if it is a generic email alias).